### PR TITLE
#EAC-1 Does Entity Have Log

### DIFF
--- a/src/AuditActiveGatePlugin.py
+++ b/src/AuditActiveGatePlugin.py
@@ -55,6 +55,14 @@ class AuditPluginRemote(RemoteBasePlugin):
         super().__init__(**kwargs)
         self.start_time=floor(datetime.now().timestamp()*1000) - self.pollingInterval
         self.end_time=None
+        self.entities_with_logs = [
+                "APPLICATION-",
+                "SERVICE-",
+                "HOST-",
+                "PROCESS_GROUP-",
+                "SYNTHETIC_TEST-",
+                "HTTP_CHECK-"
+        ]
 
     def initialize(self, **kwargs):
         """Initialize the plugin with variables provided by user in the UI
@@ -109,8 +117,8 @@ class AuditPluginRemote(RemoteBasePlugin):
         Returns:
             bool: True if Entity has Event Log
         """
-        entities_with_logs = ["APPLICATION-", "SERVICE-", "HOST-", "PROCESS_GROUP-"]
-        for entity in entities_with_logs:
+
+        for entity in self.entities_with_logs:
             if entity_id.startswith(entity):
                 return True
         return False
@@ -168,7 +176,8 @@ class AuditPluginRemote(RemoteBasePlugin):
                 log_id = str(audit_log_entry['logId']) # pylint: disable=unused-variable
                 logger.info('[Main] %s ENTRY NOT MATCHED', log_id)
 
-            if not self.event_logs_only or self.has_event_log:
+            # Ordered for short-circuiting
+            if not self.event_logs_only or self.has_event_log(request_params['entityId']):
                 request_handler.post_annotations(
                         request_params['entityId'],
                         request_params['properties'],

--- a/src/AuditActiveGatePlugin.py
+++ b/src/AuditActiveGatePlugin.py
@@ -67,7 +67,7 @@ class AuditPluginRemote(RemoteBasePlugin):
     def initialize(self, **kwargs):
         """Initialize the plugin with variables provided by user in the UI
         """
-        logger.info("Config: %s", self.config)
+        logger.info("[Main] Config: %s", self.config)
         config = kwargs['config']
 
         self.url = config['url'].strip()
@@ -101,8 +101,8 @@ class AuditPluginRemote(RemoteBasePlugin):
         changes = request_handler.get_dt_api_json(audit_log_endpoint)
         if changes and 'auditLogs' in changes.keys():
             return changes['auditLogs']
-        logging.info("Payload had no AuditLogs")
-        logging.debug("AuditLogs %s", str(changes))
+        logger.info("[Main] Payload had no AuditLogs")
+        logger.debug("[Main] AuditLogs %s", str(changes))
         return None
 
     def has_event_log(
@@ -119,7 +119,7 @@ class AuditPluginRemote(RemoteBasePlugin):
         """
 
         for entity in self.entities_with_logs:
-            if entity_id.startswith(entity):
+            if entity_id.startswith(entity, 1):
                 return True
         return False
 
@@ -177,6 +177,7 @@ class AuditPluginRemote(RemoteBasePlugin):
                 logger.info('[Main] %s ENTRY NOT MATCHED', log_id)
 
             # Ordered for short-circuiting
+            logger.debug("[Main] EntityID: %s", request_params['entityId'])
             if not self.event_logs_only or self.has_event_log(request_params['entityId']):
                 request_handler.post_annotations(
                         request_params['entityId'],

--- a/src/AuditActiveGatePlugin.py
+++ b/src/AuditActiveGatePlugin.py
@@ -91,7 +91,7 @@ class AuditPluginRemote(RemoteBasePlugin):
                 + "filter=category(\"CONFIG\")&sort=timestamp" \
                 + f"&from={self.start_time}&to={self.end_time}"
         changes = request_handler.get_dt_api_json(audit_log_endpoint)
-        if changes and 'apiToken' in changes.keys():
+        if changes and 'auditLogs' in changes.keys():
             return changes['auditLogs']
         logging.info("Payload had no AuditLogs")
         logging.debug("AuditLogs %s", str(changes))
@@ -166,7 +166,7 @@ class AuditPluginRemote(RemoteBasePlugin):
                 request_params=audit_v2_entry.extract_info(audit_log_entry, request_handler)
             else:
                 log_id = str(audit_log_entry['logId']) # pylint: disable=unused-variable
-                logger.info('[Main] %(log_id)s ENTRY NOT MATCHED')
+                logger.info('[Main] %s ENTRY NOT MATCHED', log_id)
 
             if not self.event_logs_only or self.has_event_log:
                 request_handler.post_annotations(

--- a/src/AuditActiveGatePlugin.py
+++ b/src/AuditActiveGatePlugin.py
@@ -59,7 +59,7 @@ class AuditPluginRemote(RemoteBasePlugin):
                 "APPLICATION-",
                 "SERVICE-",
                 "HOST-",
-                "PROCESS_GROUP-",
+                "PROCESS_GROUP_INSTANCE-",
                 "SYNTHETIC_TEST-",
                 "HTTP_CHECK-"
         ]

--- a/src/AuditEntryBaseHandler.py
+++ b/src/AuditEntryBaseHandler.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
- 
+
 """
 Library for Base Audit Entry Handler
 """
@@ -125,3 +125,18 @@ class AuditEntryBaseHandler():
             pgi_list = self.get_processes_from_group(entity_id, request_handler)
             entity_id = self.process_group_instance_to_entity_str(pgi_list)
         return entity_id
+
+    def has_event_log(self, entity_id: str) -> bool:
+        """Checks if the entity has event log
+
+        Args:
+            entity_id (str): Entity ID to be checked
+
+        Returns:
+            bool: True if Entity has Event Log
+        """
+        entities_with_logs = ["APPLICATION-", "SERVICE-", "HOST-", "PROCESS_GROUP-"]
+        for entity in entities_with_logs:
+            if entity_id.startswith(entity):
+                return True
+        return False

--- a/src/AuditEntryBaseHandler.py
+++ b/src/AuditEntryBaseHandler.py
@@ -104,7 +104,7 @@ class AuditEntryBaseHandler():
         if len(all_instances_str) > 0:
             all_instances_str = all_instances_str[:-1]
         pgi_list_str = f"{all_instances_str}"
-        logger.info("PGI STRING: %s", pgi_list_str)
+        logger.debug("[AuditEntryBase] PGI STRING: %s", pgi_list_str)
         return pgi_list_str
 
     def get_all_entities(

--- a/src/AuditEntryBaseHandler.py
+++ b/src/AuditEntryBaseHandler.py
@@ -22,24 +22,6 @@ from RequestHandler import RequestHandler # pylint: disable=unused-import
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
-def has_event_log(
-        self,
-        entity_id: str
-) -> bool:
-    """Checks if the entity has event log
-
-    Args:
-        entity_id (str): Entity ID to be checked
-
-    Returns:
-        bool: True if Entity has Event Log
-    """
-    entities_with_logs = ["APPLICATION-", "SERVICE-", "HOST-", "PROCESS_GROUP-"]
-    for entity in entities_with_logs:
-        if entity_id.startswith(entity):
-            return True
-    return False
-
 class AuditEntryBaseHandler():
     '''
     Base Class for Audit Entry to be Processed and Pushed.

--- a/src/AuditEntryBaseHandler.py
+++ b/src/AuditEntryBaseHandler.py
@@ -22,6 +22,24 @@ from RequestHandler import RequestHandler # pylint: disable=unused-import
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
+def has_event_log(
+        self,
+        entity_id: str
+) -> bool:
+    """Checks if the entity has event log
+
+    Args:
+        entity_id (str): Entity ID to be checked
+
+    Returns:
+        bool: True if Entity has Event Log
+    """
+    entities_with_logs = ["APPLICATION-", "SERVICE-", "HOST-", "PROCESS_GROUP-"]
+    for entity in entities_with_logs:
+        if entity_id.startswith(entity):
+            return True
+    return False
+
 class AuditEntryBaseHandler():
     '''
     Base Class for Audit Entry to be Processed and Pushed.
@@ -125,18 +143,3 @@ class AuditEntryBaseHandler():
             pgi_list = self.get_processes_from_group(entity_id, request_handler)
             entity_id = self.process_group_instance_to_entity_str(pgi_list)
         return entity_id
-
-    def has_event_log(self, entity_id: str) -> bool:
-        """Checks if the entity has event log
-
-        Args:
-            entity_id (str): Entity ID to be checked
-
-        Returns:
-            bool: True if Entity has Event Log
-        """
-        entities_with_logs = ["APPLICATION-", "SERVICE-", "HOST-", "PROCESS_GROUP-"]
-        for entity in entities_with_logs:
-            if entity_id.startswith(entity):
-                return True
-        return False

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -27,7 +27,8 @@
     {"key": "apiToken", "type": "Password"},
     {"key": "pollingInterval", "type": "Integer", "defaultValue": 1},
     {"key": "verify_ssl", "type": "Boolean", "defaultValue": true},
-    {"key": "timezone", "type": "String", "defaultValue": "UTC"}
+    {"key": "timezone", "type": "String", "defaultValue": "UTC"},
+    {"key": "event_logs_only", "type": "Boolean", "defaultValue": false}
   ],
   "configUI": {
     "displayName": "Automated Configuration Audit",
@@ -36,7 +37,8 @@
       {"key": "apiToken", "displayName": "API Token with auditLogs.read, entities.read and events.ingest", "displayOrder": 2, "displayHint": "Current Token Format: dt.PUBLICSECTION.PRIVATESECTION"},
       {"key": "pollingInterval", "displayName": "Polling frequency (in minutes)", "displayOrder": 3, "displayHint": "For example: 5"},
       {"key": "verify_ssl", "displayName": "Verify URL SSL Certicate", "displayOrder": 4},
-      {"key": "timezone", "displayName": "Timezone", "displayOrder": 5, "displayHint": "For example: America/Chicago"}
+      {"key": "timezone", "displayName": "Timezone", "displayOrder": 5, "displayHint": "For example: America/Chicago"},
+      {"key": "event_logs_only", "displayName": "Only Post Events With Event Logs", "displayOrder": 6}
     ]
   }
 }


### PR DESCRIPTION
## Changes
- Added option to user-provided arguments to post all entity changes or only about entities with Audit Logs
- Added check to see if the the entityId in the log entry has a log (key is event_logs_only and is bool type)
- If either all posts are allowed or the entityId has a log, the Annotation is push, else it is withheld

## Other Fixes
- Bug from #EAC-14 blocked this ticket, so I resolved it and merged it into here
- Log entries missing prefix showing file they are from.

## Notes

Known entity log list built by hand (Application, Service, Process_Group, 